### PR TITLE
Removing unused session

### DIFF
--- a/core/src/main/java/com/valtech/aapm/restrictions/HasPropertyValuesPattern.java
+++ b/core/src/main/java/com/valtech/aapm/restrictions/HasPropertyValuesPattern.java
@@ -27,7 +27,6 @@ import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionPattern;
 import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 
-import javax.jcr.Session;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -38,8 +37,6 @@ import java.util.Objects;
 public class HasPropertyValuesPattern implements RestrictionPattern {
 
     private final String originalTree;
-    private final Session session;
-
     private final String name;
     private final String values;
     private final String[] status;
@@ -53,8 +50,7 @@ public class HasPropertyValuesPattern implements RestrictionPattern {
 
     private final boolean negate;
 
-    HasPropertyValuesPattern(String propertyValues,String originalTree,Session session) {
-        this.session = session;
+    HasPropertyValuesPattern(String propertyValues,String originalTree) {
         this.originalTree = originalTree;
 
         // allow#property=test
@@ -87,9 +83,9 @@ public class HasPropertyValuesPattern implements RestrictionPattern {
 
     }
 
-    static RestrictionPattern create(PropertyState stringProperty,String originalTree,Session session) {
+    static RestrictionPattern create(PropertyState stringProperty,String originalTree) {
         if (stringProperty.count() == 1) {
-            return new HasPropertyValuesPattern(stringProperty.getValue(Type.STRING),originalTree,session);
+            return new HasPropertyValuesPattern(stringProperty.getValue(Type.STRING),originalTree);
         } else {
             return RestrictionPattern.EMPTY;
         }

--- a/core/src/main/java/com/valtech/aapm/restrictions/PropertyValueRestrictionProvider.java
+++ b/core/src/main/java/com/valtech/aapm/restrictions/PropertyValueRestrictionProvider.java
@@ -22,21 +22,14 @@ import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.*;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.*;
 
-import javax.jcr.Session;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
 @Component(service = RestrictionProvider.class, immediate=true)
 public class PropertyValueRestrictionProvider extends AbstractRestrictionProvider {
-
-    @Reference(fieldOption = FieldOption.REPLACE,
-            cardinality = ReferenceCardinality.OPTIONAL,
-            policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
 
     private static final String HAS_PROPERTY_VALUES = "hasPropertyValues";
 
@@ -58,14 +51,10 @@ public class PropertyValueRestrictionProvider extends AbstractRestrictionProvide
         tree (path) = /jcr:system/rep:permissionStore/crx.default/aapm-restricted/626084805/0
      **/
     public RestrictionPattern getPattern(String oakPath, Tree tree) {
-        Session session = null;
-        if (this.rrf != null && this.rrf.getThreadResourceResolver() != null) {
-            session = this.rrf.getThreadResourceResolver().adaptTo(Session.class);
-        }
         if (oakPath != null) {
             PropertyState property = tree.getProperty(HAS_PROPERTY_VALUES);
             if (property != null) {
-                return HasPropertyValuesPattern.create(property,oakPath,session);
+                return HasPropertyValuesPattern.create(property,oakPath);
             }
         }
         return RestrictionPattern.EMPTY;
@@ -73,15 +62,11 @@ public class PropertyValueRestrictionProvider extends AbstractRestrictionProvide
 
     @Override
     public RestrictionPattern getPattern(String oakPath, Set<Restriction> restrictions) {
-        Session session = null;
-        if (this.rrf != null && this.rrf.getThreadResourceResolver() != null) {
-            session = this.rrf.getThreadResourceResolver().adaptTo(Session.class);
-        }
         if (oakPath != null) {
             for (Restriction r : restrictions) {
                 String name = r.getDefinition().getName();
                 if (HAS_PROPERTY_VALUES.equals(name)) {
-                    return HasPropertyValuesPattern.create(r.getProperty(),oakPath,session);
+                    return HasPropertyValuesPattern.create(r.getProperty(),oakPath);
                 }
             }
         }

--- a/core/src/test/java/com/valtech/aapm/restrictions/HasPropertyValuesPatternBugsToFixTest.java
+++ b/core/src/test/java/com/valtech/aapm/restrictions/HasPropertyValuesPatternBugsToFixTest.java
@@ -23,8 +23,6 @@ import static junitx.framework.Assert.assertFalse;
 
 import java.util.ArrayList;
 import java.util.Set;
-
-import javax.jcr.Session;
 import javax.jcr.SimpleCredentials;
 
 import org.apache.jackrabbit.JcrConstants;
@@ -60,15 +58,6 @@ public class HasPropertyValuesPatternBugsToFixTest {
         contentRepository = myOak.createContentRepository();
         adminSession = contentRepository.login(new SimpleCredentials("admin", "admin".toCharArray()), "test");
         root = adminSession.getLatestRoot();
-
-        // Repository repo = new Jcr(myOak).createRepository();
-        // Session session = repo.login(new SimpleCredentials("admin", "admin".toCharArray()),
-        // "test");
-
-        // Repository repo = new Jcr(myOak).createRepository();
-
-        // repo.login()
-
     }
 
     // region Bugs to fix
@@ -87,10 +76,9 @@ public class HasPropertyValuesPatternBugsToFixTest {
                                                                                          // deny
                                                                                          // rule
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -118,10 +106,9 @@ public class HasPropertyValuesPatternBugsToFixTest {
                                                                                          // deny
                                                                                          // rule
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -140,10 +127,9 @@ public class HasPropertyValuesPatternBugsToFixTest {
         Tree tree = root.getTree("/content/dam/aapm-test/test-deny");
         String propertyValues = "deny#int$myNumberProperty>4";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -166,10 +152,9 @@ public class HasPropertyValuesPatternBugsToFixTest {
         Tree tree = root.getTree("/content/dam/aapm-test/test-deny");
         String propertyValues = "deny#int$myNumbers<72";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -191,10 +176,9 @@ public class HasPropertyValuesPatternBugsToFixTest {
         Tree tree = root.getTree("/content/dam/aapm-test/test-deny");
         String propertyValues = "deny#int$myNumbers<72";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -213,10 +197,9 @@ public class HasPropertyValuesPatternBugsToFixTest {
         String propertyValues = "deny#date$myDate>2022-12-08T10:05:57.5946+08:00"; // negate deny
                                                                                    // rule
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -236,10 +219,9 @@ public class HasPropertyValuesPatternBugsToFixTest {
         // Tree tree = root.getTree("/content/dam/aapm-test/test-allow");
         String propertyValues = "allow#string$!myProperty==toto";
         String originalTree = "/content/dam/aapm-test/test-allow";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(asset, whatever);
 
@@ -276,10 +258,9 @@ public class HasPropertyValuesPatternBugsToFixTest {
         // Tree tree = root.getTree("/content/dam/aapm-test/test-allow");
         String propertyValues = "allow#string$myProperty==toto";
         String originalTree = "/content/dam/aapm-test/test-allow/subfolder";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(subfolderContainingGrandSonAsset, whatever);
 

--- a/core/src/test/java/com/valtech/aapm/restrictions/HasPropertyValuesPatternTest.java
+++ b/core/src/test/java/com/valtech/aapm/restrictions/HasPropertyValuesPatternTest.java
@@ -23,7 +23,6 @@ import static junitx.framework.Assert.assertFalse;
 
 import java.util.Set;
 
-import javax.jcr.Session;
 import javax.jcr.SimpleCredentials;
 
 import org.apache.jackrabbit.JcrConstants;
@@ -58,15 +57,6 @@ public class HasPropertyValuesPatternTest {
         contentRepository = myOak.createContentRepository();
         adminSession = contentRepository.login(new SimpleCredentials("admin", "admin".toCharArray()), "test");
         root = adminSession.getLatestRoot();
-
-        // Repository repo = new Jcr(myOak).createRepository();
-        // Session session = repo.login(new SimpleCredentials("admin", "admin".toCharArray()),
-        // "test");
-
-        // Repository repo = new Jcr(myOak).createRepository();
-
-        // repo.login()
-
     }
 
     // region State of art
@@ -80,11 +70,10 @@ public class HasPropertyValuesPatternTest {
         Tree tree = root.getTree("/content/dam/aapm-test/test-deny");
         String propertyValues = "deny#string$cq:tags==properties:orientation/portrait";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -100,11 +89,10 @@ public class HasPropertyValuesPatternTest {
         Tree tree = root.getTree("/content/dam/aapm-test/test-deny");
         String propertyValues = "deny#string$cq:tags==properties:orientation/portrait";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -120,11 +108,10 @@ public class HasPropertyValuesPatternTest {
                                                                                          // deny
                                                                                          // rule
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -141,10 +128,9 @@ public class HasPropertyValuesPatternTest {
         Tree tree = root.getTree("/content/dam/aapm-test/test-deny");
         String propertyValues = "deny#string$cq:tags==properties:orientation/portrait";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -163,10 +149,9 @@ public class HasPropertyValuesPatternTest {
                                                                                          // deny
                                                                                          // rule
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -187,10 +172,9 @@ public class HasPropertyValuesPatternTest {
         Tree tree = root.getTree("/content/dam/aapm-test/test-deny");
         String propertyValues = "deny#string$cq:tags==properties:orientation/portrait";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -211,10 +195,9 @@ public class HasPropertyValuesPatternTest {
         Tree tree = root.getTree("/content/dam/aapm-test/test-deny");
         String propertyValues = "deny#int$myNumbers==75";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -235,10 +218,9 @@ public class HasPropertyValuesPatternTest {
         Tree tree = root.getTree("/content/dam/aapm-test/test-deny");
         String propertyValues = "deny#int$myNumbers==72";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -257,10 +239,9 @@ public class HasPropertyValuesPatternTest {
         Tree tree = root.getTree("/content/dam/aapm-test/test-deny");
         String propertyValues = "deny#int$myNumbers==72";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -279,10 +260,9 @@ public class HasPropertyValuesPatternTest {
         Tree tree = root.getTree("/content/dam/aapm-test/test-deny");
         String propertyValues = "deny#date$myDate==2022-03-01'T'20:07:11.000000";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -296,10 +276,9 @@ public class HasPropertyValuesPatternTest {
         Tree notAnAsset = root.getTree("/content/dam/aapm-test/test-deny");
         String propertyValues = "deny#int$myNumbers==72";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(notAnAsset, whatever);
 
@@ -320,10 +299,9 @@ public class HasPropertyValuesPatternTest {
         Tree tree = root.getTree("/content/dam/aapm-test/test-deny");
         String propertyValues = "deny#int$myNumbers>72";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -344,10 +322,9 @@ public class HasPropertyValuesPatternTest {
         Tree tree = root.getTree("/content/dam/aapm-test/test-deny");
         String propertyValues = "deny#int$myNumbers>72";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -365,10 +342,9 @@ public class HasPropertyValuesPatternTest {
         String propertyValues = "deny#string$cq:tags==properties:orientation/portrait"; // negate
                                                                                         // deny rule
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -385,10 +361,9 @@ public class HasPropertyValuesPatternTest {
         Tree tree = root.getTree("/content/dam/aapm-test/test-deny");
         String propertyValues = "deny#int$myNumberProperty==4";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -405,10 +380,9 @@ public class HasPropertyValuesPatternTest {
         Tree tree = root.getTree("/content/dam/aapm-test/test-deny");
         String propertyValues = "deny#int$myNumberProperty<4";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -426,10 +400,9 @@ public class HasPropertyValuesPatternTest {
         String propertyValues = "deny#date$myDate==2022-12-08T10:05:57.5946+08:00"; // negate deny
                                                                                     // rule
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(tree, whatever);
 
@@ -454,10 +427,9 @@ public class HasPropertyValuesPatternTest {
         // Tree tree = root.getTree("/content/dam/aapm-test/test-allow");
         String propertyValues = "allow#string$myProperty==toto";
         String originalTree = "/content/dam/aapm-test/test-allow";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(asset, whatever);
 
@@ -483,10 +455,9 @@ public class HasPropertyValuesPatternTest {
         // Tree tree = root.getTree("/content/dam/aapm-test/test-allow");
         String propertyValues = "allow#string$myProperty==toto";
         String originalTree = "/content/dam/aapm-test/test-allow/subfolder";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(subfolderContainingAssets, whatever);
 
@@ -510,10 +481,9 @@ public class HasPropertyValuesPatternTest {
         // Tree tree = root.getTree("/content/dam/pbop-hackathon-2021/test-allow");
         String propertyValues = "allow#string$myProperty==toto";
         String originalTree = "/content/dam/pbop-hackathon-2021/test-allow/subfolder";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(subfolderContainingAssets, whatever);
 
@@ -539,10 +509,9 @@ public class HasPropertyValuesPatternTest {
                 + "jcr:content/renditions/cq5dam.thumbnail.140.100.png");
         String propertyValues = "allow#string$myProperty==toto";
         String originalTree = "/content/dam/aapm-test/test-allow";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(testedTree, whatever);
 
@@ -569,10 +538,9 @@ public class HasPropertyValuesPatternTest {
                 + "jcr:content/renditions/cq5dam.thumbnail.140.100.png");
         String propertyValues = "allow#string$myProperty==toto";
         String originalTree = "/content/dam/aapm-test/test-allow";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(testedTree, whatever);
 
@@ -599,10 +567,9 @@ public class HasPropertyValuesPatternTest {
                 + "jcr:content/renditions/cq5dam.thumbnail.140.100.png");
         String propertyValues = "allow#string$myProperty==toto";
         String originalTree = "/content/dam/aapm-test/test-allow";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(testedTree, whatever);
 
@@ -629,10 +596,9 @@ public class HasPropertyValuesPatternTest {
                 + "jcr:content/renditions/cq5dam.thumbnail.140.100.png");
         String propertyValues = "allow#string$myProperty==toto";
         String originalTree = "/content/dam/aapm-test/test-allow";
-        Session session = null;
         PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches(testedTree, whatever);
 
@@ -644,16 +610,14 @@ public class HasPropertyValuesPatternTest {
 
     @Test
     public void equals_returns_false_if_at_least_one_internal_field_is_different() {
-        Session session = null;
-
         String propertyValues = "allow#string$myProperty==toto";
         String originalTree = "/content/dam/pbop-hackathon-2021/test-allow";
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         String propertyValues2 = "deny#string$myProperty==toto";
         String originalTree2 = "/content/dam/pbop-hackathon-2021/test-allow";
         HasPropertyValuesPattern hasPropertyValuesPattern2 =
-                new HasPropertyValuesPattern(propertyValues2, originalTree2, session);
+                new HasPropertyValuesPattern(propertyValues2, originalTree2);
 
         assertFalse(hasPropertyValuesPattern.equals(hasPropertyValuesPattern2));
 
@@ -665,10 +629,8 @@ public class HasPropertyValuesPatternTest {
     public void matches_returns_false() {
         String propertyValues = "deny#string$cq:tags==properties:orientation/portrait";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
-        PropertyState whatever = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches();
 
@@ -679,9 +641,8 @@ public class HasPropertyValuesPatternTest {
     public void matches_returns_false_for_whatever_path() {
         String propertyValues = "deny#string$cq:tags==properties:orientation/portrait";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
 
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         boolean doesItMatch = hasPropertyValuesPattern.matches("/whatever/path");
 
@@ -692,8 +653,7 @@ public class HasPropertyValuesPatternTest {
     public void equals_returns_true_if_same_reference() {
         String propertyValues = "deny#string$cq:tags==properties:orientation/portrait";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
 
         assertTrue(hasPropertyValuesPattern.equals(hasPropertyValuesPattern));
     }
@@ -702,8 +662,7 @@ public class HasPropertyValuesPatternTest {
     public void equals_returns_false_for_objects_of_different_types() {
         String propertyValues = "deny#string$cq:tags==properties:orientation/portrait";
         String originalTree = "/content/dam/aapm-test/test-deny";
-        Session session = null;
-        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree, session);
+        HasPropertyValuesPattern hasPropertyValuesPattern = new HasPropertyValuesPattern(propertyValues, originalTree);
         String nothingSpecial = "test";
 
         assertFalse(hasPropertyValuesPattern.equals(nothingSpecial));

--- a/core/src/test/java/com/valtech/aapm/restrictions/PropertyValueRestrictionProviderTest.java
+++ b/core/src/test/java/com/valtech/aapm/restrictions/PropertyValueRestrictionProviderTest.java
@@ -25,8 +25,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
-import javax.jcr.Session;
-
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.plugins.memory.PropertyStates;
@@ -63,7 +61,6 @@ class PropertyValueRestrictionProviderTest {
 
     @Test
     public void getPattern_nominal_case() {
-        Session session = null;
         Type<String> type = Type.STRING;
         String oakPath = "/my/path";
         String name = "hasPropertyValues";
@@ -75,7 +72,7 @@ class PropertyValueRestrictionProviderTest {
         HashSet<Restriction> restrictions = new HashSet<>();
         restrictions.add(restriction);
         HasPropertyValuesPattern expectedRestrictionPattern =
-                new HasPropertyValuesPattern(matchedConditionPropertyValue, oakPath, session);
+                new HasPropertyValuesPattern(matchedConditionPropertyValue, oakPath);
 
 
         RestrictionPattern computedRestrictionPattern = testedProvider.getPattern(oakPath, restrictions);
@@ -86,7 +83,6 @@ class PropertyValueRestrictionProviderTest {
 
     @Test
     public void getPattern_returns_empty_pattern_restriction_when_special_property_is_a_multiple_one() {
-        Session session = null;
         Type<Iterable<String>> type = Type.STRINGS;
         String oakPath = "/my/path";
         String name = "hasPropertyValues";

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -71,3 +71,25 @@ This show-cases classic unit testing of the code contained in the bundle. To
 test, execute:
 
     mvn clean test
+
+## Tips
+### Using a session for the algorithm "match"
+If you want to use a session to get some data in the tree of the oak repository, adding the following in the class PropertyValueRestrictionProvider :
+
+    @Reference(fieldOption = FieldOption.REPLACE,
+    cardinality = ReferenceCardinality.OPTIONAL,
+    policyOption = ReferencePolicyOption.GREEDY)
+    private ResourceResolverFactory rrf;
+
+Now to get a session use :
+
+    Session session = null;
+    if (this.rrf != null && this.rrf.getThreadResourceResolver() != null) {
+        session = this.rrf.getThreadResourceResolver().adaptTo(Session.class);
+    }
+
+and use it the methods
+    
+    public RestrictionPattern getPattern(...)
+
+/ !! \ WARNING : use the session carefully, the "match" algorithm must be very fast because it will be used for a lot of paths !!!


### PR DESCRIPTION
Session variable was first implemented "in case of" but was not used at all.
Thus all the session variables have been removed and a special developer documentation section has been added if a developer needs to use jcr session in the algorithm "match"